### PR TITLE
Remove `charset=utf-8` from `Content-Type` header

### DIFF
--- a/lib/teamtailor/request.rb
+++ b/lib/teamtailor/request.rb
@@ -46,7 +46,7 @@ module Teamtailor
         "Authorization": "Token token=#{api_token}",
         "X-Api-Version" => api_version,
         "User-Agent" => "teamtailor-rb v#{Teamtailor::VERSION}",
-        "Content-Type" => "application/vnd.api+json; charset=utf-8",
+        "Content-Type" => "application/vnd.api+json",
       }
     end
   end

--- a/spec/teamtailor/request_spec.rb
+++ b/spec/teamtailor/request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Teamtailor::Request do
             "Authorization": "Token token=#{api_token}",
             "X-Api-Version" => 20_161_108,
             "User-Agent" => "teamtailor-rb v#{Teamtailor::VERSION}",
-            "Content-Type" => "application/vnd.api+json; charset=utf-8",
+            "Content-Type" => "application/vnd.api+json",
           }
         )
         .to_return(status: 200, body: { nonsense: true }.to_json, headers: {
@@ -29,7 +29,7 @@ RSpec.describe Teamtailor::Request do
                      "X-Rate-Limit-Limit" => 100,
                      "X-Rate-Limit-Remaining" => 100,
                      "X-Rate-Limit-Reset" => 1,
-                     "Content-Type" => "application/vnd.api+json; charset=utf-8",
+                     "Content-Type" => "application/vnd.api+json",
                    })
 
       page_result = request.call
@@ -77,7 +77,7 @@ RSpec.describe Teamtailor::Request do
               "Authorization": "Token token=#{api_token}",
               "X-Api-Version" => 20_161_108,
               "User-Agent" => "teamtailor-rb v#{Teamtailor::VERSION}",
-              "Content-Type" => "application/vnd.api+json; charset=utf-8",
+              "Content-Type" => "application/vnd.api+json",
             }
           )
           .to_return(status: 401, body: "")


### PR DESCRIPTION
The `charset=utf-8` was removed from the `Content-Type` header due to a recent error where requests started failing with the message:  
*"All requests that create or update must use the 'application/vnd.api+json' Content-Type. This request specified 'application/vnd.api+json; charset=utf-8'."*  

Despite keeping the `X-Api-Version` and `Authorization` headers unchanged, the API was rejecting requests because of the `charset=utf-8` specification. Removing it ensures the API functions without errors and remains operational.